### PR TITLE
CI: fix flaky iOS simulator destination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,32 @@ jobs:
           }
           EOF
 
+      - name: Select iOS Simulator
+        id: sim
+        run: |
+          # Pick an available iPhone simulator by UDID instead of hardcoding a model name.
+          # The runner image's device list changes over time, so 'name=iPhone 16' intermittently
+          # fails with "Unable to find a device matching the provided destination specifier".
+          echo "Available simulators:"
+          xcrun simctl list devices available
+          UDID=$(xcrun simctl list devices available \
+            | grep -E 'iPhone' \
+            | grep -oiE '[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}' \
+            | head -1)
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator found on the runner"
+            exit 1
+          fi
+          echo "Selected simulator UDID: $UDID"
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
       - name: Build and Test
         run: |
           set -o pipefail
           xcodebuild test \
             -project iOS/FastWeather.xcodeproj \
             -scheme FastWeather \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
             -skip-testing:FastWeatherTests/OpenMeteoAPIParameterTests/testForecastDaysUsesCorrectValues \
             -skip-testing:FastWeatherTests/OpenMeteoAPIParameterTests/testLiveAPICallWithCorrectParameters \
             CODE_SIGN_IDENTITY="" \


### PR DESCRIPTION
Fixes the intermittent CI failures (failure emails from the PR #77 merge run and one earlier PR run).

**Cause:** the iOS Tests job hardcoded `-destination 'platform=iOS Simulator,name=iPhone 16'`. That model isn't reliably present on the `macos-15` runner — its simulator list rotates with the runner image — so runs intermittently failed with `Unable to find a device matching the provided destination specifier` (exit 70). The merge-commit run hit it; the very next commit (version bump) passed the full suite, confirming it's infra flakiness, not code.

**Fix:** a step that selects the first available iPhone simulator by **UDID** and passes `-destination "platform=iOS Simulator,id=<udid>"`, which is robust to model/name changes. It also prints the available simulator list for debugging.

This PR's own CI run validates the fix.