### PR TITLE
iOS: resilient forecast fetch + daylight day-over-day change

### DIFF
--- a/iOS/FastWeather/Services/WeatherService.swift
+++ b/iOS/FastWeather/Services/WeatherService.swift
@@ -84,21 +84,71 @@ class WeatherService: ObservableObject {
     }
 
     /// Executes an Open-Meteo API request and returns the raw response data.
-    /// If the server returns a non-200 status, decodes the Open-Meteo error body
+    /// Retries transient failures — request timeouts, dropped connections, and
+    /// HTTP 429/5xx rate-limit or server errors — up to `maxRetries` times with
+    /// exponential backoff before giving up. Without this, a single network blip or
+    /// rate-limit spike drops the caller back to stale/partial (light) cached data,
+    /// which is what produced the "only a few days" / "missing hourly" reports.
+    /// A non-transient non-200 status decodes the Open-Meteo error body
     /// ({"error":true,"reason":"..."}) and throws a descriptive NSError rather than
     /// letting the caller receive a generic DecodingError on the response body.
-    private func apiData(for url: URL, timeout: TimeInterval = 15) async throws -> Data {
-        let request = apiRequest(for: url, timeout: timeout)
-        let (data, response) = try await URLSession.shared.data(for: request)
-        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
-            if let errorBody = try? JSONDecoder().decode(OpenMeteoErrorResponse.self, from: data),
-               errorBody.error {
-                throw NSError(domain: "OpenMeteo", code: httpResponse.statusCode,
-                              userInfo: [NSLocalizedDescriptionKey: errorBody.reason ?? "Unknown API error"])
+    private func apiData(for url: URL, timeout: TimeInterval = 15, maxRetries: Int = 2) async throws -> Data {
+        var attempt = 0
+        while true {
+            do {
+                let request = apiRequest(for: url, timeout: timeout)
+                let (data, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                    // Retry rate-limit (429) and server (5xx) errors; surface everything else.
+                    if Self.isRetryableStatus(httpResponse.statusCode), attempt < maxRetries {
+                        attempt += 1
+                        try await Task.sleep(nanoseconds: Self.backoffNanoseconds(forAttempt: attempt))
+                        continue
+                    }
+                    if let errorBody = try? JSONDecoder().decode(OpenMeteoErrorResponse.self, from: data),
+                       errorBody.error {
+                        throw NSError(domain: "OpenMeteo", code: httpResponse.statusCode,
+                                      userInfo: [NSLocalizedDescriptionKey: errorBody.reason ?? "Unknown API error"])
+                    }
+                    throw URLError(.badServerResponse)
+                }
+                return data
+            } catch {
+                // Retry transient network errors (timeout, connection lost, DNS blip).
+                if Self.isTransientNetworkError(error), attempt < maxRetries {
+                    attempt += 1
+                    try? await Task.sleep(nanoseconds: Self.backoffNanoseconds(forAttempt: attempt))
+                    continue
+                }
+                throw error
             }
-            throw URLError(.badServerResponse)
         }
-        return data
+    }
+
+    /// HTTP statuses worth retrying: rate limiting and transient server-side faults.
+    private static func isRetryableStatus(_ status: Int) -> Bool {
+        status == 429 || (500...599).contains(status)
+    }
+
+    /// Transient client-side network failures that a brief retry can clear. Deliberately
+    /// excludes `.notConnectedToInternet` (no point retrying a device that's offline) and
+    /// `.badServerResponse` (already decided not to retry that status above).
+    private static func isTransientNetworkError(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        switch urlError.code {
+        case .timedOut, .networkConnectionLost, .cannotConnectToHost,
+             .cannotFindHost, .dnsLookupFailed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Exponential backoff: ~0.5s before the first retry, ~1.5s before the second —
+    /// long enough to clear a blip, short enough not to strand the UI.
+    private static func backoffNanoseconds(forAttempt attempt: Int) -> UInt64 {
+        let seconds = 0.5 * pow(3.0, Double(attempt - 1))
+        return UInt64(seconds * 1_000_000_000)
     }
     
     // Cache durations
@@ -358,6 +408,68 @@ class WeatherService: ObservableObject {
         // Light fetch for list display — detail view will request full data on open
         await fetchWeatherForDate(for: city, dateOffset: 0, includeHourly: false)
     }
+
+    /// Clears any prior failure marker for this city/date and re-attempts a full fetch.
+    /// Once a full fetch fails, `failedCacheKeys` guards the list-row `.task` from
+    /// re-fetching (so it doesn't loop on a persistent error), which leaves a city stuck
+    /// showing truncated light data. The detail view's "Try Again" button calls this to
+    /// escape that state.
+    func retryFetch(for city: City, dateOffset: Int) async {
+        let cacheKey = WeatherCacheKey(cityId: city.id, dateOffset: dateOffset)
+        await MainActor.run { self.failedCacheKeys.remove(cacheKey) }
+        await fetchWeatherForDate(for: city, dateOffset: dateOffset, includeHourly: true)
+    }
+
+    /// Change in daylight duration (in seconds) for the given day versus the day before it —
+    /// positive means more daylight than the previous day, negative means less. Powers the
+    /// "N minutes more/less than yesterday" note under the daylight total.
+    ///
+    /// First reuses per-day data already cached by day navigation ("look ahead") — each
+    /// visited day is fetched with `daylight_duration`, so once the previous day has been
+    /// viewed this costs nothing. Only when the previous day isn't cached (e.g. a cold
+    /// today-view, which never pre-fetches yesterday) does it fall back to a tiny dedicated
+    /// request — daily=daylight_duration only, no hourly — that doesn't bloat the main
+    /// payload. Returns nil on any error.
+    func fetchDaylightChangeVsPreviousDay(for city: City, dateOffset: Int) async -> Double? {
+        // Fast path: both days are already in the weather cache from day navigation.
+        let currentKey = WeatherCacheKey(cityId: city.id, dateOffset: dateOffset)
+        let previousKey = WeatherCacheKey(cityId: city.id, dateOffset: dateOffset - 1)
+        if let current = weatherCache[currentKey]?.daily?.daylightDuration?.value(at: 0),
+           let previous = weatherCache[previousKey]?.daily?.daylightDuration?.value(at: 0) {
+            return current - previous
+        }
+
+        // With past_days=P and forecast_days=F, the daily array covers dateOffsets -P…(F-1),
+        // so a given dateOffset lives at index (dateOffset + P). Size the window to include
+        // both the target day and the day before it.
+        let previousOffset = dateOffset - 1
+        let pastDays = max(0, -previousOffset)
+        let forecastDays = max(1, dateOffset + 1)
+
+        var components = URLComponents(string: baseURL)!
+        components.queryItems = [
+            URLQueryItem(name: "latitude", value: String(city.latitude)),
+            URLQueryItem(name: "longitude", value: String(city.longitude)),
+            URLQueryItem(name: "daily", value: "daylight_duration"),
+            URLQueryItem(name: "past_days", value: String(pastDays)),
+            URLQueryItem(name: "forecast_days", value: String(forecastDays)),
+            URLQueryItem(name: "timezone", value: "auto")
+        ]
+        guard let url = components.url else { return nil }
+
+        do {
+            let data = try await apiData(for: url)
+            let response = try JSONDecoder().decode(WeatherResponse.self, from: data)
+            guard let durations = response.daily?.daylightDuration else { return nil }
+            let targetIndex = dateOffset + pastDays
+            guard let target = durations.value(at: targetIndex),
+                  let previous = durations.value(at: targetIndex - 1) else { return nil }
+            return target - previous
+        } catch {
+            debugLog("❌ Failed to fetch daylight change: \(error.localizedDescription)")
+            return nil
+        }
+    }
     
     // Fetch weather data for a specific date offset.
     // includeHourly: false → skip hourly, forecast_days=3 (fast; used by list/background refresh)
@@ -430,11 +542,14 @@ class WeatherService: ObservableObject {
         }
         
         do {
-            let data = try await apiData(for: url)
-            
+            // The full fetch (hourly + 16 daily variables) is a large payload; give it
+            // 30s on slow cellular so it doesn't time out and fall back to light data.
+            // The light fetch (3 days, no hourly) is small — keep the tighter 15s.
+            let data = try await apiData(for: url, timeout: includeHourly ? 30 : 15)
+
             let decoder = JSONDecoder()
             let response = try decoder.decode(WeatherResponse.self, from: data)
-            
+
             // For dateOffset = 0 (today), use the current weather directly
             // For dateOffset > 0 (future), extract that day's data from daily/hourly arrays
             let weatherData: WeatherData

--- a/iOS/FastWeather/Views/CityDetailView.swift
+++ b/iOS/FastWeather/Views/CityDetailView.swift
@@ -25,6 +25,9 @@ struct CityDetailView: View {
     @State private var removalCityName = "" // Captured at trigger time to prevent dialog flashing
     @State private var isRefreshing = false
     @State private var cacheMetadata: CachedWeather?
+    /// Change in daylight (seconds) vs. the previous day, for the "N min more/less than
+    /// yesterday" note. Fetched separately since the previous day isn't in the forecast array.
+    @State private var daylightChangeSeconds: Double?
     
     // Backward compatibility initializer (defaults to today)
     init(city: City, dateOffset: Int = 0, selectedDate: Date = Date()) {
@@ -33,9 +36,18 @@ struct CityDetailView: View {
         self.selectedDate = selectedDate
     }
     
+    private var cacheKey: WeatherCacheKey {
+        WeatherCacheKey(cityId: city.id, dateOffset: dateOffset)
+    }
+
     private var weather: WeatherData? {
-        let cacheKey = WeatherCacheKey(cityId: city.id, dateOffset: dateOffset)
-        return weatherService.weatherCache[cacheKey]
+        weatherService.weatherCache[cacheKey]
+    }
+
+    /// The most recent full fetch for this city/date failed. Used to surface a retry
+    /// banner instead of silently showing truncated (light, 3-day/no-hourly) data.
+    private var fetchFailed: Bool {
+        weatherService.failedCacheKeys.contains(cacheKey)
     }
     
     private var isSaved: Bool {
@@ -54,12 +66,31 @@ struct CityDetailView: View {
         await weatherService.fetchWeatherForDate(for: city, dateOffset: dateOffset)
         isRefreshing = false
         // Refresh cache metadata
-        let cacheKey = WeatherCacheKey(cityId: city.id, dateOffset: dateOffset)
         cacheMetadata = await weatherService.getCacheMetadata(for: cacheKey)
     }
-    
+
+    /// Ensures the detail view has full data (hourly + 16-day) when it appears, and loads
+    /// cache metadata. If only light data is cached (hourly missing) it upgrades to a full
+    /// fetch — even for a city the list marked failed, so opening the detail acts as a retry.
+    private func loadWeather() async {
+        let cached = weatherService.weatherCache[cacheKey]
+        // Today/future forecasts carry hourly; a nil hourly means we only have light data.
+        let needsFull = cached == nil || (dateOffset >= 0 && cached?.hourly == nil)
+        if needsFull {
+            await weatherService.retryFetch(for: city, dateOffset: dateOffset)
+        }
+        cacheMetadata = await weatherService.getCacheMetadata(for: cacheKey)
+    }
+
+    /// Clears the failure marker and re-attempts a full fetch (the "Try Again" button).
+    private func retry() async {
+        isRefreshing = true
+        await weatherService.retryFetch(for: city, dateOffset: dateOffset)
+        isRefreshing = false
+        cacheMetadata = await weatherService.getCacheMetadata(for: cacheKey)
+    }
+
     private func loadCacheMetadata() async {
-        let cacheKey = WeatherCacheKey(cityId: city.id, dateOffset: dateOffset)
         cacheMetadata = await weatherService.getCacheMetadata(for: cacheKey)
     }
     
@@ -264,17 +295,28 @@ struct CityDetailView: View {
                             
                             if settingsManager.settings.showDaylightDuration,
                                let daylight = daily.daylightDuration?.value(at: 0) {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "sun.max")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                        .accessibilityHidden(true)
-                                    Text("\(formatDuration(daylight)) of daylight")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
+                                let changePhrase = daylightChangeSeconds.flatMap { daylightChangePhrase($0) }
+                                VStack(spacing: 2) {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "sun.max")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                            .accessibilityHidden(true)
+                                        Text("\(formatDuration(daylight)) of daylight")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    if let changePhrase {
+                                        Text(changePhrase)
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                            .multilineTextAlignment(.center)
+                                    }
                                 }
                                 .accessibilityElement(children: .ignore)
-                                .accessibilityLabel("\(formatDuration(daylight)) of daylight")
+                                .accessibilityLabel(changePhrase.map {
+                                    "\(formatDuration(daylight)) of daylight, \($0)"
+                                } ?? "\(formatDuration(daylight)) of daylight")
                             }
                             
                             if settingsManager.settings.showSunshineDuration,
@@ -655,10 +697,52 @@ struct CityDetailView: View {
         }
     }
     
+    /// Shown when the full forecast fetch failed. Tells the user the data on screen may
+    /// be incomplete and offers a retry, rather than silently presenting truncated data.
+    private var forecastErrorBanner: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.orange)
+                    .accessibilityHidden(true)
+                Text("Couldn't load the full forecast")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            }
+            Text("The 16-day and hourly forecast may be incomplete. Check your connection and try again.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            Button {
+                Task { await retry() }
+            } label: {
+                Label("Try Again", systemImage: "arrow.clockwise")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isRefreshing)
+            .accessibilityHint("Reloads the full 16-day and hourly forecast")
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color.orange.opacity(0.12))
+        .cornerRadius(12)
+        .padding(.horizontal)
+        .accessibilityElement(children: .contain)
+    }
+
     var body: some View {
         let _ = debugLog("🟢 CityDetailView body called for \(city.name), selectedAlert: \(selectedAlert?.event ?? "nil")")
         ScrollView {
             VStack(spacing: 24) {
+                // Full-fetch failure banner — shown whether or not partial (light) data
+                // is present, so a truncated forecast is never displayed as if complete.
+                if fetchFailed {
+                    forecastErrorBanner
+                }
+
                 if let weather = weather {
                     // Cache status indicator (if data is stale)
                     if let metadata = cacheMetadata, metadata.isStale {
@@ -804,10 +888,12 @@ struct CityDetailView: View {
                         }
                     }
                     
-                } else {
+                } else if !fetchFailed {
                     ProgressView("Loading weather data...")
                         .padding()
                 }
+                // When fetchFailed and there's no cached data, the banner above stands alone
+                // instead of spinning forever.
             }
             .padding(.vertical)
         }
@@ -828,7 +914,13 @@ struct CityDetailView: View {
             }
         }
         .task {
-            await loadCacheMetadata()
+            await loadWeather()
+        }
+        .task(id: "\(city.id)-\(dateOffset)-daylight") {
+            // Reset first so a stale other-city value never flashes while this loads.
+            daylightChangeSeconds = nil
+            guard settingsManager.settings.showDaylightDuration else { return }
+            daylightChangeSeconds = await weatherService.fetchDaylightChangeVsPreviousDay(for: city, dateOffset: dateOffset)
         }
         .refreshable {
             await refreshWeather()
@@ -915,6 +1007,26 @@ struct CityDetailView: View {
         case let (nil, lo?): return "Forecast low \(formatTemperature(lo))"
         default: return "Forecast temperature unavailable"
         }
+    }
+
+    /// "1 minute less than yesterday" / "2 minutes more than today" for the daylight change.
+    /// Always compares the displayed day against the day before it; the reference word tracks
+    /// the day-navigation offset so it reads naturally both looking back and looking forward:
+    /// today→"yesterday", tomorrow→"today", any other day→"the previous day". Returns nil when
+    /// the change rounds to under a minute (near the solstices), so we omit the note rather
+    /// than showing "0 minutes".
+    private func daylightChangePhrase(_ deltaSeconds: Double) -> String? {
+        let minutes = Int((abs(deltaSeconds) / 60).rounded())
+        guard minutes >= 1 else { return nil }
+        let unit = minutes == 1 ? "minute" : "minutes"
+        let direction = deltaSeconds >= 0 ? "more" : "less"
+        let reference: String
+        switch dateOffset {
+        case 0: reference = "yesterday"
+        case 1: reference = "today"
+        default: reference = "the previous day"
+        }
+        return "\(minutes) \(unit) \(direction) than \(reference)"
     }
 
     private var shareSubject: String {
@@ -2171,7 +2283,7 @@ struct DailyForecastRow: View {
     private func formatDuration(_ seconds: Double) -> String {
         let hours = Int(seconds / 3600)
         let minutes = Int((seconds.truncatingRemainder(dividingBy: 3600)) / 60)
-        
+
         if minutes > 0 {
             return "\(hours)h \(minutes)m"
         } else {


### PR DESCRIPTION
## Summary

Two iOS improvements addressing user reports of unreliable forecasts, plus a small daylight-trend feature.

### Forecast fetch resilience
Users reported the 16-day forecast sometimes showing only a few days and the 24-hour hourly forecast going missing. Root cause: on launch `refreshAllWeather()` does a **light** fetch (3 days, no hourly); the list row upgrades to a **full** fetch, but any failure sets `failedCacheKeys`, which blocks retries and leaves the light snapshot on screen with no error shown.

- `apiData` now **retries transient failures** (timeouts, dropped connections, DNS blips, HTTP 429/5xx) up to twice with exponential backoff. Skips offline and genuine client errors so it fails fast where retrying is moot.
- Full (hourly + 16-day) fetches get a **30s timeout** instead of 15s — the large payload was timing out on slow cellular and falling back to light data.
- `CityDetailView` runs a full fetch on appear (auto-retry for a city the list marked failed) and shows a **"Couldn't load the full forecast" banner with a Try Again button** instead of silently rendering truncated data.
- Added `WeatherService.retryFetch()` to clear the failure marker and re-fetch.

### Daylight day-over-day change
Under the daylight total, show how the day compares to the day before, e.g. **"2 minutes less than yesterday"**. Direction is automatic; the note is omitted when the change rounds under a minute (near the solstices). Reference word tracks day navigation (today→yesterday, tomorrow→today, else "the previous day") so it reads naturally looking both back and forward. Rendered as a second line so it can't clip, with an enriched VoiceOver label; the `14h 54m` abbreviation is left unchanged.

- `fetchDaylightChangeVsPreviousDay()` is **cache-first**: reuses per-day data the day-navigation already cached, falling back to a tiny daily-only request only when the previous day isn't cached (cold today-view).

## Testing
- `xcodebuild` build succeeds; OpenMeteoAPIParameterTests pass (10/10).
- Index math for the daylight delta verified against the live Open-Meteo API (both backward and forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)