### PR TITLE
Windows: locale-aware default units on first run

### DIFF
--- a/windows/fastweather/app.py
+++ b/windows/fastweather/app.py
@@ -14,6 +14,7 @@ import wx
 from . import __version__, browse_favorites
 from .constants import USER_GUIDE_URL
 from .city_data import flatten_cities, load_cached_cities
+from .locale_units import locale_default_units
 from .models.city import CityStore
 from .models.settings import AppSettings
 from .models.weather import describe_cloud_cover
@@ -62,6 +63,12 @@ class MainFrame(wx.Frame):
         self.current_full_data = None
 
         self.cities.load()
+        # First run only: seed units from the user's Windows region (matches
+        # iOS locale-aware defaults). Saved config always wins afterward.
+        if not os.path.exists(self.config_file):
+            regional = locale_default_units()
+            if regional:
+                self.settings["units"].update(regional)
         self.load_config()
 
         # Background fetch manager

--- a/windows/fastweather/locale_units.py
+++ b/windows/fastweather/locale_units.py
@@ -1,0 +1,81 @@
+"""Locale-aware default units, seeded from the user's Windows region.
+
+Applied only on first run (when no config.json exists yet); after that the
+user's saved unit choices always win. Mirrors the iOS app seeding units from
+locale, and in particular picks the right wind unit per country — wind is not
+simply metric/imperial: many countries report it in meters per second, others
+in km/h, a few in mph.
+
+The country sets are a curated, easily-adjustable mapping; when the region
+can't be determined the caller keeps the existing (US) defaults.
+"""
+
+# Temperature / precipitation / pressure in US customary.
+_FAHRENHEIT = {"US", "BS", "BZ", "KY", "PW", "FM", "MH"}
+_INCH_PRECIP = {"US"}
+_INHG_PRESSURE = {"US"}
+_MMHG_PRESSURE = {"RU"}          # Russia reports pressure in mmHg
+_MILES_DISTANCE = {"US", "GB"}   # US + UK use miles for distance
+
+# Wind: the interesting one.
+_MPH_WIND = {"US", "GB"}
+_MS_WIND = {  # national services / public reports commonly use meters/second
+    "NO", "SE", "FI", "DK", "IS",          # Nordics
+    "EE", "LV", "LT",                      # Baltics
+    "RU", "UA", "BY",                      # former USSR
+    "CN", "JP", "KR",                      # East Asia
+    "NL",                                  # KNMI
+}
+# everything else metric -> km/h
+
+
+def detect_country():
+    """Return the user's ISO-3166 alpha-2 country code (Windows), or None."""
+    try:
+        import ctypes
+        buf = ctypes.create_unicode_buffer(16)
+        # GetUserDefaultGeoName: the user's Country/Region (Win10 1709+).
+        if ctypes.windll.kernel32.GetUserDefaultGeoName(buf, len(buf)) > 0 and buf.value:
+            return buf.value.strip().upper()[:2]
+    except Exception:
+        pass
+    try:
+        import ctypes
+        buf = ctypes.create_unicode_buffer(85)
+        if ctypes.windll.kernel32.GetUserDefaultLocaleName(buf, len(buf)) and "-" in buf.value:
+            return buf.value.split("-")[-1].strip().upper()[:2]
+    except Exception:
+        pass
+    return None
+
+
+def default_units_for_country(code):
+    """Return a units dict for an ISO country code (pure; testable)."""
+    code = (code or "").upper()
+    if code in _MPH_WIND:
+        wind = "mph"
+    elif code in _MS_WIND:
+        wind = "m/s"
+    else:
+        wind = "km/h"
+    if code in _INHG_PRESSURE:
+        pressure = "inHg"
+    elif code in _MMHG_PRESSURE:
+        pressure = "mmHg"
+    else:
+        pressure = "hPa"
+    return {
+        "temperature": "F" if code in _FAHRENHEIT else "C",
+        "wind_speed": wind,
+        "precipitation": "in" if code in _INCH_PRECIP else "mm",
+        "distance": "mi" if code in _MILES_DISTANCE else "km",
+        "pressure": pressure,
+    }
+
+
+def locale_default_units():
+    """Units for the current Windows region, or None if it can't be determined."""
+    code = detect_country()
+    if not code:
+        return None
+    return default_units_for_country(code)

--- a/windows/tests/test_locale_units.py
+++ b/windows/tests/test_locale_units.py
@@ -1,0 +1,42 @@
+import unittest
+
+from fastweather.locale_units import default_units_for_country
+
+
+class LocaleUnitsTests(unittest.TestCase):
+    def test_us(self):
+        u = default_units_for_country("US")
+        self.assertEqual(u, {"temperature": "F", "wind_speed": "mph",
+                             "precipitation": "in", "distance": "mi",
+                             "pressure": "inHg"})
+
+    def test_uk_metric_but_mph_and_miles(self):
+        u = default_units_for_country("GB")
+        self.assertEqual(u["temperature"], "C")
+        self.assertEqual(u["wind_speed"], "mph")   # UK reports wind in mph
+        self.assertEqual(u["distance"], "mi")       # and distance in miles
+        self.assertEqual(u["precipitation"], "mm")
+        self.assertEqual(u["pressure"], "hPa")
+
+    def test_meters_per_second_countries(self):
+        for code in ("NO", "SE", "FI", "RU", "CN", "JP", "NL"):
+            self.assertEqual(default_units_for_country(code)["wind_speed"], "m/s", code)
+
+    def test_kmh_default_metric(self):
+        for code in ("FR", "ES", "IT", "AU", "CA", "BR"):
+            u = default_units_for_country(code)
+            self.assertEqual(u["wind_speed"], "km/h", code)
+            self.assertEqual(u["temperature"], "C", code)
+
+    def test_russia_pressure_mmhg(self):
+        self.assertEqual(default_units_for_country("RU")["pressure"], "mmHg")
+
+    def test_unknown_country_is_metric_kmh(self):
+        u = default_units_for_country("ZZ")
+        self.assertEqual(u["wind_speed"], "km/h")
+        self.assertEqual(u["temperature"], "C")
+        self.assertEqual(u["pressure"], "hPa")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Seeds temperature/wind/precipitation/distance/pressure from the user's Windows
region on first launch (matches the iOS locale-aware defaults). A returning
user's saved units always win.

Wind is handled specifically — it's not simply metric/imperial: **mph** (US,
UK), **m/s** (Nordics, Baltics, former USSR, CN/JP/KR, NL), **km/h** elsewhere.
Also Russia → mmHg, US → inHg, UK → miles.

- `locale_units.py`: region detection (GetUserDefaultGeoName + locale fallback)
  and a curated country→units map.
- first-run seeding only when `config.json` is absent.
- tests for the mapping (79 total). Verified first-run seeding and
  returning-user precedence end-to-end.