### PR TITLE
Release cleanup: Windows v3.0.0 + platform-scoped tags/updater

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,14 +1,15 @@
 name: WeatherFast (Windows)
 
 # Adopted from QuickMail's release workflow, adapted to Python/PyInstaller +
-# Inno Setup. Pushing a version tag (e.g. v1.2.0) builds the app and installer
-# and publishes a GitHub Release with both assets. The in-app updater reads the
-# latest release and downloads the *-Setup.exe asset. Pull requests that touch
-# the Windows app build (and run tests) but never publish a release.
+# Inno Setup. Pushing a `windows-v<semver>` tag (e.g. windows-v3.0.0) builds the
+# app and installer and publishes a GitHub Release with both assets. The tag is
+# Windows-specific so it never collides with this repo's iOS/web release tags,
+# and the in-app updater only looks at `windows-v*` releases. Pull requests that
+# touch the Windows app build (and run tests) but never publish a release.
 
 on:
   push:
-    tags: ['v*']
+    tags: ['windows-v*']
   pull_request:
     paths:
       - 'windows/**'
@@ -43,10 +44,10 @@ jobs:
       # The tag is the single source of truth for the release version and must
       # match the package __version__, which the in-app updater compares against.
       - name: Verify tag matches package version
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/windows-v')
         shell: pwsh
         run: |
-          $tag = '${{ github.ref_name }}'.TrimStart('v')
+          $tag = '${{ github.ref_name }}' -replace '^windows-v', ''
           $init = Get-Content windows/fastweather/__init__.py -Raw
           if ($init -notmatch '__version__\s*=\s*"([^"]+)"') { throw "Could not read __version__" }
           $ver = $Matches[1]
@@ -59,8 +60,8 @@ jobs:
         id: ver
         shell: pwsh
         run: |
-          if ('${{ github.ref }}' -like 'refs/tags/v*') {
-            $v = '${{ github.ref_name }}'.TrimStart('v')
+          if ('${{ github.ref }}' -like 'refs/tags/windows-v*') {
+            $v = '${{ github.ref_name }}' -replace '^windows-v', ''
           } else {
             $init = Get-Content windows/fastweather/__init__.py -Raw
             $null = $init -match '__version__\s*=\s*"([^"]+)"'
@@ -97,10 +98,10 @@ jobs:
           retention-days: 14
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/windows-v')
         uses: softprops/action-gh-release@v2
         with:
-          name: WeatherFast ${{ github.ref_name }}
+          name: WeatherFast ${{ steps.ver.outputs.version }} (Windows)
           generate_release_notes: true
           files: |
             windows/dist/WeatherFast.exe

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,56 @@
+# Versioning and Releasing
+
+FastWeather is one repository containing three independent apps (Windows, iOS,
+Web). Each app has its **own version line** and its **own release tag prefix**,
+so a release of one platform never collides with or triggers another.
+
+## Tag convention
+
+Use a platform prefix and a semantic version:
+
+| Platform | Tag format          | Example            |
+|----------|---------------------|--------------------|
+| Windows  | `windows-v<semver>` | `windows-v3.0.0`   |
+| iOS      | `ios-v<semver>`     | `ios-v1.5.8`       |
+| Web      | `web-v<semver>`     | `web-v2.0.0`       |
+
+Rules:
+- Lowercase `v`, semantic version `MAJOR.MINOR.PATCH`.
+- One prefix per platform; never a bare `vX` tag (it's ambiguous in a
+  multi-platform repo and would match more than one automation).
+- Tags are permanent history — do not delete or move published tags/releases.
+
+### Legacy tags (pre-convention, left as history)
+
+`v1.0`, `v1.1`, `v2WindowsApp`, `V2WebApp`, `v1.2-webapp`, `V1WebApp`,
+`V1iOSBLD5`, `V1iOSBLD9`. These predate this convention and are kept as-is.
+New releases follow the table above.
+
+## Windows
+
+Source of truth for the version is `windows/fastweather/__init__.py`
+(`__version__`). To cut a release:
+
+1. Bump `__version__` (e.g. `3.0.0`) and merge to `main`.
+2. Tag and push: `git tag windows-v3.0.0 && git push origin windows-v3.0.0`.
+
+The `windows-release` workflow (triggered by `windows-v*`) verifies the tag
+matches `__version__`, runs the tests, builds the PyInstaller exe and the Inno
+Setup installer, and publishes a GitHub Release with both assets. The in-app
+auto-updater only considers `windows-v*` releases, compares against
+`__version__`, and offers the `*-Setup.exe` asset.
+
+The current Windows app is **v3.0.0** — a full rebuild that supersedes the
+legacy `v2WindowsApp` build.
+
+## iOS
+
+Released via the `ios-release` workflow (manual `workflow_dispatch` with a build
+number) to TestFlight / the App Store; see `.github/workflows/README-ios-release.md`
+and `iOS/RELEASING.md`. Mark a shipped version with an `ios-v<marketing_version>`
+tag for history. iOS releases are **not** cut by pushing a tag.
+
+## Web
+
+Deployed to weatherfast.online per `webapp/DEPLOYMENT.md`. Mark a shipped
+version with a `web-v<semver>` tag for history.

--- a/windows/fastweather/__init__.py
+++ b/windows/fastweather/__init__.py
@@ -8,4 +8,4 @@ Note: the Python package/module is still imported as ``fastweather`` (import
 name only, never shown to users); the product name is WeatherFast.
 """
 
-__version__ = "1.1"
+__version__ = "3.0.0"

--- a/windows/fastweather/services/updater.py
+++ b/windows/fastweather/services/updater.py
@@ -14,7 +14,10 @@ from .. import __version__
 from . import http
 
 GITHUB_REPO = "kellylford/FastWeather"
-LATEST_RELEASE_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+RELEASES_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases?per_page=30"
+# This is a multi-platform repo; Windows releases are tagged `windows-v<semver>`
+# so the updater never picks up an iOS or web release.
+WINDOWS_TAG_PREFIX = "windows-v"
 
 
 def _version_tuple(v):
@@ -29,23 +32,40 @@ def is_newer(latest, current):
     return a > b
 
 
-def check_for_update(current_version=None):
-    """Return {'version', 'url', 'notes'} if a newer release exists, else None.
+def _windows_version(tag):
+    """Return the semver from a `windows-v<semver>` tag, else None."""
+    if tag and tag.startswith(WINDOWS_TAG_PREFIX):
+        return tag[len(WINDOWS_TAG_PREFIX):]
+    return None
 
+
+def check_for_update(current_version=None):
+    """Return {'version', 'url', 'notes'} for the newest Windows release if it
+    is newer than the running version, else None.
+
+    Considers only `windows-v*` releases (this repo also ships iOS and web).
     Raises on network/API failure so a manual check can report "couldn't check".
     """
     current = current_version or __version__
-    data = http.get_json(LATEST_RELEASE_URL)
-    tag = (data.get("tag_name") or "").lstrip("v")
-    if not tag or not is_newer(tag, current):
+    releases = http.get_json(RELEASES_URL) or []
+    best, best_ver = None, None
+    for r in releases:
+        if r.get("draft") or r.get("prerelease"):
+            continue
+        ver = _windows_version(r.get("tag_name") or "")
+        if not ver:
+            continue
+        if best is None or _version_tuple(ver) > _version_tuple(best_ver):
+            best, best_ver = r, ver
+
+    if best is None or not is_newer(best_ver, current):
         return None
     url = None
-    for asset in data.get("assets", []):
-        name = (asset.get("name") or "").lower()
-        if name.endswith("setup.exe"):
+    for asset in best.get("assets", []):
+        if (asset.get("name") or "").lower().endswith("setup.exe"):
             url = asset.get("browser_download_url")
             break
-    return {"version": tag, "url": url, "notes": data.get("body") or ""}
+    return {"version": best_ver, "url": url, "notes": best.get("body") or ""}
 
 
 def download_installer(url, progress=None):

--- a/windows/tests/test_updater.py
+++ b/windows/tests/test_updater.py
@@ -21,29 +21,40 @@ class UpdaterTests(unittest.TestCase):
         self.assertFalse(updater.is_newer("1.1", "1.1.0"))
         self.assertTrue(updater.is_newer("1.1.1", "1.1"))
 
-    def test_update_available_with_installer_asset(self):
-        updater.http.get_json = lambda url: {
-            "tag_name": "v2.0", "body": "Notes",
-            "assets": [
-                {"name": "WeatherFast.exe",
-                 "browser_download_url": "http://x/WeatherFast.exe"},
-                {"name": "WeatherFast-2.0-Setup.exe",
-                 "browser_download_url": "http://x/WeatherFast-2.0-Setup.exe"},
-            ],
-        }
-        info = updater.check_for_update("1.1")
-        self.assertEqual(info["version"], "2.0")
-        self.assertTrue(info["url"].endswith("Setup.exe"))  # picked the installer asset
+    def test_update_available_picks_newest_windows_release(self):
+        updater.http.get_json = lambda url: [
+            # newest windows release
+            {"tag_name": "windows-v3.1.0", "body": "Notes", "assets": [
+                {"name": "WeatherFast.exe", "browser_download_url": "http://x/WeatherFast.exe"},
+                {"name": "WeatherFast-3.1.0-Setup.exe",
+                 "browser_download_url": "http://x/WeatherFast-3.1.0-Setup.exe"},
+            ]},
+            {"tag_name": "windows-v3.0.0", "assets": []},
+            # non-windows releases must be ignored
+            {"tag_name": "ios-v1.6.0", "assets": []},
+            {"tag_name": "web-v2.0.0", "assets": []},
+        ]
+        info = updater.check_for_update("3.0.0")
+        self.assertEqual(info["version"], "3.1.0")
+        self.assertTrue(info["url"].endswith("Setup.exe"))
         self.assertEqual(info["notes"], "Notes")
 
+    def test_ignores_non_windows_and_prerelease(self):
+        updater.http.get_json = lambda url: [
+            {"tag_name": "ios-v9.9.9", "assets": []},
+            {"tag_name": "web-v9.9.9", "assets": []},
+            {"tag_name": "windows-v9.9.9", "prerelease": True, "assets": []},
+        ]
+        self.assertIsNone(updater.check_for_update("3.0.0"))
+
     def test_no_update_when_not_newer(self):
-        updater.http.get_json = lambda url: {"tag_name": "v1.1", "assets": []}
-        self.assertIsNone(updater.check_for_update("1.1"))
+        updater.http.get_json = lambda url: [{"tag_name": "windows-v3.0.0", "assets": []}]
+        self.assertIsNone(updater.check_for_update("3.0.0"))
 
     def test_update_without_installer_asset(self):
-        updater.http.get_json = lambda url: {"tag_name": "v3.0", "assets": []}
-        info = updater.check_for_update("1.1")
-        self.assertEqual(info["version"], "3.0")
+        updater.http.get_json = lambda url: [{"tag_name": "windows-v4.0.0", "assets": []}]
+        info = updater.check_for_update("3.0.0")
+        self.assertEqual(info["version"], "4.0.0")
         self.assertIsNone(info["url"])
 
 


### PR DESCRIPTION
Establishes a per-platform tag convention (windows-v*/ios-v*/web-v*), bumps the rebuilt Windows app to 3.0.0, scopes the release workflow + in-app updater to windows-v* only, and documents releasing in docs/RELEASING.md. No tags/releases deleted; iOS/web deploys untouched.