### PR TITLE
Repo rename FastWeather -> WeatherFast: update references

### DIFF
--- a/CityData/WEBAPP_TROUBLESHOOTING.md
+++ b/CityData/WEBAPP_TROUBLESHOOTING.md
@@ -402,7 +402,7 @@ The Windows desktop app correctly displays all 101 countries. It uses the same J
 ## Contact Info for Handoff
 
 User: kellylford  
-Repo: github.com/kellylford/FastWeather  
+Repo: github.com/kellylford/WeatherFast  
 Branch: main  
 Date: January 18, 2026  
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -56,12 +56,12 @@ Any changes to this privacy policy will be posted in this file and reflected in 
 ## Open Source
 
 FastWeather is open-source software. You can review the complete source code at:
-https://github.com/kellylford/FastWeather
+https://github.com/kellylford/WeatherFast
 
 ## Contact
 
 For questions about this privacy policy, please open an issue on the GitHub repository:
-https://github.com/kellylford/FastWeather/issues
+https://github.com/kellylford/WeatherFast/issues
 
 ## Your Rights
 

--- a/iOS/USER_GUIDE.md
+++ b/iOS/USER_GUIDE.md
@@ -242,5 +242,5 @@ No API key required. No account required. No data tracking.
 
 ## Reporting Issues
 
-[https://github.com/kellylford/FastWeather/issues](https://github.com/kellylford/FastWeather/issues)
+[https://github.com/kellylford/WeatherFast/issues](https://github.com/kellylford/WeatherFast/issues)
 

--- a/installer/weatherfast.iss
+++ b/installer/weatherfast.iss
@@ -14,7 +14,7 @@
 #define MyAppName "WeatherFast"
 #define MyAppPublisher "Kelly Ford"
 #define MyAppExeName "WeatherFast.exe"
-#define MyAppURL "https://github.com/kellylford/FastWeather"
+#define MyAppURL "https://github.com/kellylford/WeatherFast"
 
 [Setup]
 ; Stable AppId so upgrades replace the prior install (never change this GUID).

--- a/webapp/PWA_DEPLOYMENT_GUIDE.md
+++ b/webapp/PWA_DEPLOYMENT_GUIDE.md
@@ -49,7 +49,7 @@ webapp/international-cities-cached.json
 # If using GitHub Pages:
 1. Go to your repo → Settings → Pages
 2. Source: Deploy from main branch, /webapp folder
-3. Your site will be at: https://kellylford.github.io/FastWeather/
+3. Your site will be at: https://kellylford.github.io/WeatherFast/
 ```
 
 ### HTTPS Requirement

--- a/webapp/WEB_README.md
+++ b/webapp/WEB_README.md
@@ -55,7 +55,7 @@ This application implements the following accessibility features:
 
 1. Clone the repository and switch to the WebApp branch:
    ```bash
-   git clone https://github.com/kellylford/FastWeather.git
+   git clone https://github.com/kellylford/WeatherFast.git
    cd FastWeather
    git checkout WebApp
    ```

--- a/windows/RELEASE_NOTES_v2.md
+++ b/windows/RELEASE_NOTES_v2.md
@@ -107,6 +107,6 @@ None reported
 
 ---
 
-**Full Changelog:** [v1.1...v2.0](https://github.com/kellylford/FastWeather/compare/v1.1...v2.0)
+**Full Changelog:** [v1.1...v2.0](https://github.com/kellylford/WeatherFast/compare/v1.1...v2.0)
 
-**Download:** See [Releases](https://github.com/kellylford/FastWeather/releases)
+**Download:** See [Releases](https://github.com/kellylford/WeatherFast/releases)

--- a/windows/fastweather/constants.py
+++ b/windows/fastweather/constants.py
@@ -22,7 +22,7 @@ DEFAULT_TIMEOUT = 10
 
 # Published, formatted user guide (built from docs/user-guide.md by the
 # publish-user-guide workflow and served from GitHub Pages).
-USER_GUIDE_URL = "https://kellylford.github.io/FastWeather/"
+USER_GUIDE_URL = "https://kellylford.github.io/WeatherFast/"
 
 # Default seed cities: display name -> [lat, lon]
 DEFAULT_CITIES = {

--- a/windows/fastweather/services/updater.py
+++ b/windows/fastweather/services/updater.py
@@ -13,7 +13,7 @@ import tempfile
 from .. import __version__
 from . import http
 
-GITHUB_REPO = "kellylford/FastWeather"
+GITHUB_REPO = "kellylford/WeatherFast"
 RELEASES_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases?per_page=30"
 # This is a multi-platform repo; Windows releases are tagged `windows-v<semver>`
 # so the updater never picks up an iOS or web release.


### PR DESCRIPTION
Point the user-guide link, auto-updater, installer, and docs at kellylford/WeatherFast and the new Pages URL. Version stays 3.0.0; the 3.0.0 release will be deleted and republished from this commit with the corrected URLs.