### PR TITLE
Windows 3.0.1: fix Enter on alert browser lists

### DIFF
--- a/windows/fastweather/__init__.py
+++ b/windows/fastweather/__init__.py
@@ -8,4 +8,4 @@ Note: the Python package/module is still imported as ``fastweather`` (import
 name only, never shown to users); the product name is WeatherFast.
 """
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"

--- a/windows/fastweather/ui/dialogs/alert_browser_dialog.py
+++ b/windows/fastweather/ui/dialogs/alert_browser_dialog.py
@@ -55,7 +55,7 @@ class AlertBrowserDialog(wx.Dialog):
         s = wx.BoxSizer(wx.VERTICAL)
         s.Add(wx.StaticText(p, label="Choose a region to browse active alerts:"),
               0, wx.ALL, 8)
-        self.region_list = wx.ListBox(p, style=wx.LB_SINGLE)
+        self.region_list = wx.ListBox(p, style=wx.LB_SINGLE | wx.WANTS_CHARS)
         for r in svc.REGIONS:
             self.region_list.Append(r["name"])
         self.region_list.SetSelection(0)
@@ -112,7 +112,7 @@ class AlertBrowserDialog(wx.Dialog):
 
         self.digest_status = wx.StaticText(p, label="")
         s.Add(self.digest_status, 0, wx.LEFT | wx.BOTTOM, 8)
-        self.group_list = wx.ListBox(p, style=wx.LB_SINGLE)
+        self.group_list = wx.ListBox(p, style=wx.LB_SINGLE | wx.WANTS_CHARS)
         s.Add(self.group_list, 1, wx.EXPAND | wx.ALL, 8)
         self.open_group_btn = wx.Button(p, label="View Affected Areas")
         self.open_group_btn.Disable()
@@ -138,7 +138,7 @@ class AlertBrowserDialog(wx.Dialog):
         s.Add(self.group_back, 0, wx.ALL, 8)
         self.group_title = wx.StaticText(p, label="")
         s.Add(self.group_title, 0, wx.LEFT | wx.BOTTOM, 8)
-        self.area_list = wx.ListBox(p, style=wx.LB_SINGLE)
+        self.area_list = wx.ListBox(p, style=wx.LB_SINGLE | wx.WANTS_CHARS)
         s.Add(self.area_list, 1, wx.EXPAND | wx.ALL, 8)
         self.open_area_btn = wx.Button(p, label="View Details")
         self.open_area_btn.Disable()
@@ -171,10 +171,20 @@ class AlertBrowserDialog(wx.Dialog):
             focus_ctrl.SetFocus()
 
     def _bind_enter(self, ctrl, handler):
-        """Enter on a list advances to the next level (as elsewhere in the app)."""
+        """Enter on a list advances to the next level (as elsewhere in the app).
+
+        The list must be created with wx.WANTS_CHARS, or the dialog consumes
+        Enter/Tab for navigation and this handler never sees them. Tab is
+        re-implemented here so keyboard focus can still leave the list.
+        """
         def on_key(evt):
-            if evt.GetKeyCode() in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER):
+            kc = evt.GetKeyCode()
+            if kc in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER):
                 handler(evt)
+            elif kc == wx.WXK_TAB:
+                flags = (wx.NavigationKeyEvent.IsBackward if evt.ShiftDown()
+                         else wx.NavigationKeyEvent.IsForward)
+                ctrl.Navigate(flags)
             else:
                 evt.Skip()
         ctrl.Bind(wx.EVT_KEY_DOWN, on_key)

--- a/windows/fastweather/ui/dialogs/alerts_dialog.py
+++ b/windows/fastweather/ui/dialogs/alerts_dialog.py
@@ -30,7 +30,7 @@ class AlertsDialog(wx.Dialog):
         ls = wx.BoxSizer(wx.VERTICAL)
         self.status = wx.StaticText(list_page, label="Checking for alerts...")
         ls.Add(self.status, 0, wx.ALL, 8)
-        self.list_box = wx.ListBox(list_page, style=wx.LB_SINGLE)
+        self.list_box = wx.ListBox(list_page, style=wx.LB_SINGLE | wx.WANTS_CHARS)
         ls.Add(self.list_box, 1, wx.EXPAND | wx.ALL, 8)
         self.view_btn = wx.Button(list_page, label="View Details")
         self.view_btn.Disable()
@@ -111,8 +111,13 @@ class AlertsDialog(wx.Dialog):
         self.list_box.SetFocus()
 
     def _on_list_key(self, event):
-        if event.GetKeyCode() in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER):
+        kc = event.GetKeyCode()
+        if kc in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER):
             self.on_view(event)
+        elif kc == wx.WXK_TAB:
+            flags = (wx.NavigationKeyEvent.IsBackward if event.ShiftDown()
+                     else wx.NavigationKeyEvent.IsForward)
+            self.list_box.Navigate(flags)
         else:
             event.Skip()
 


### PR DESCRIPTION
Enter did nothing on the Browse Weather Alerts region/group/area lists (and the per-city alerts list) because those wx.Dialog listboxes lacked wx.WANTS_CHARS, so the dialog ate the Enter key before the handler saw it. Match the working city-list config (WANTS_CHARS + Return/Tab handling). Ships as 3.0.1 so 3.0.0 users get it via auto-update.