### PR TITLE
Windows: version back to 3.0.0 (defer release)

### DIFF
--- a/windows/fastweather/__init__.py
+++ b/windows/fastweather/__init__.py
@@ -8,4 +8,4 @@ Note: the Python package/module is still imported as ``fastweather`` (import
 name only, never shown to users); the product name is WeatherFast.
 """
 
-__version__ = "3.0.1"
+__version__ = "3.0.0"


### PR DESCRIPTION
Keep the Enter fix; revert version to 3.0.0. Real windows-v3.0.0 release deferred until verification is done.