### PR TITLE
Windows 3.0.1: show alerts in the weather report; fix wrapped alert text

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -64,6 +64,21 @@ jobs:
           }
           Write-Host "Version OK: $ver"
 
+      # Release notes are written by hand per version and published as the
+      # release body (the generated commit changelog is appended below them).
+      # Checked here so a missing file fails fast, before the build and signing,
+      # rather than at the publish step.
+      - name: Verify release notes exist
+        if: startsWith(github.ref, 'refs/tags/windows-v')
+        shell: pwsh
+        run: |
+          $v = '${{ github.ref_name }}' -replace '^windows-v', ''
+          $notes = "windows/RELEASE_NOTES_$v.md"
+          if (-not (Test-Path $notes)) {
+            throw "Missing $notes. Write the release notes for $v and commit them before tagging."
+          }
+          Write-Host "Release notes OK: $notes"
+
       - name: Determine version
         id: ver
         shell: pwsh
@@ -150,6 +165,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: WeatherFast ${{ steps.ver.outputs.version }} (Windows)
+          body_path: windows/RELEASE_NOTES_${{ steps.ver.outputs.version }}.md
           generate_release_notes: true
           files: |
             windows/dist/WeatherFast.exe

--- a/windows/RELEASE_NOTES_3.0.1.md
+++ b/windows/RELEASE_NOTES_3.0.1.md
@@ -1,0 +1,53 @@
+WeatherFast 3.0.1 brings weather alerts into the city's own weather report and
+makes alert text far easier to read.
+
+## Weather alerts in the full weather report
+
+Previously, the city list could mark a city as having an alert, but opening
+that city's Full Weather showed no sign of it — the alert was only reachable
+from the Weather menu. Alerts now appear in the report itself, directly under
+the city heading and ahead of the forecast:
+
+```
+Report for Madison, Wisconsin
+ALERTS
+MODERATE: Heat Advisory - Heat Advisory issued July 26 at 5:10AM CDT... - until Sun Jul 26 09:00 PM
+CURRENT
+...
+```
+
+- Press **Enter** on an alert to open its full text: description, safety
+  instructions, affected areas, valid period, and a button to open the
+  official NWS page.
+- A check that fails is never reported as "no alerts". It says so plainly and
+  offers a line you can press Enter on to try again.
+- Cities outside the US omit the section entirely rather than showing an empty
+  one, since the National Weather Service has no coverage there.
+- Alerts are shown for today only — a warning in force now says nothing about
+  another day's forecast.
+
+## Clearer alert list entries
+
+The city list previously appended a bare `[ALERT]`, which read identically for
+an extreme tornado warning and a minor frost advisory. It now names the most
+severe alert, and how many others there are:
+
+```
+Madison, Wisconsin - 78°F, Cloudy (High: 80°F, Low: 60°F)  [EXTREME: Tornado Warning, +1 more]
+```
+
+The window title also leads with the severity when a city has active alerts, so
+a screen reader announces it on entering the report.
+
+## Fixes
+
+- **Alert text no longer breaks mid-sentence.** The National Weather Service
+  hard-wraps its text at about 68 columns, and each of those physical lines was
+  becoming its own row — stranding fragments like "illnesses." alone on a line.
+  Alert text is now rejoined into whole paragraphs, one per row. This affects
+  every place alerts are shown, including the Weather Alerts sheet and the
+  alert browser.
+- **Enter now works on the weather report.** Rows in the report list never
+  received the Enter key, because the list was created without the style that
+  lets a control claim it.
+- A city row's alert marker is no longer lost when its weather refreshes.

--- a/windows/fastweather/__init__.py
+++ b/windows/fastweather/__init__.py
@@ -8,4 +8,4 @@ Note: the Python package/module is still imported as ``fastweather`` (import
 name only, never shown to users); the product name is WeatherFast.
 """
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"

--- a/windows/fastweather/app.py
+++ b/windows/fastweather/app.py
@@ -26,7 +26,9 @@ from .ui.dialogs.config_dialog import WeatherConfigDialog
 from .ui.dialogs.location_browser import LocationBrowserDialog
 from .ui.events import EVT_FETCH_RESULT
 from .services import alert_service, location_service, updater
+from .ui.alert_format import RETRY, city_row_badge, highest, section_lines
 from .ui.dialogs.alert_browser_dialog import AlertBrowserDialog
+from .ui.dialogs.alert_detail_dialog import AlertDetailDialog
 from .ui.dialogs.alerts_dialog import AlertsDialog
 from .ui.dialogs.around_me_dialog import AroundMeDialog
 from .ui.dialogs.historical_dialog import HistoricalDialog
@@ -61,6 +63,16 @@ class MainFrame(wx.Frame):
         self.browse_favs = browse_favorites.load()
         self.day_offset = 0      # detailed-view date navigation (-7..+7)
         self.current_full_data = None
+
+        # Alert state. Row badges are kept separately from the weather text so a
+        # weather refresh can't drop a badge (and vice versa); the detailed
+        # view's ALERTS section tracks its own fetch state so "couldn't check"
+        # is never rendered as "no alerts".
+        self._row_text = {}        # city -> weather line, without the badge
+        self._row_badges = {}      # city -> badge suffix ("" when clear)
+        self.full_alert_state = "off"
+        self.full_alerts = []
+        self.full_alert_error = ""
 
         self.cities.load()
         # First run only: seed units from the user's Windows region (matches
@@ -174,7 +186,8 @@ class MainFrame(wx.Frame):
         head_row.Add(self.btn_config, 0, wx.ALIGN_CENTER_VERTICAL)
         fv_sizer.Add(head_row, 0, wx.EXPAND | wx.ALL, 10)
 
-        self.full_display = AccessibleLinesPanel(self.full_view)
+        self.full_display = AccessibleLinesPanel(self.full_view, activatable=True)
+        self.full_display.set_activate_handler(self._open_alert)
         fv_sizer.Add(self.full_display, 1, wx.EXPAND | wx.ALL, 10)
         self.full_view.SetSizer(fv_sizer)
 
@@ -785,6 +798,51 @@ class MainFrame(wx.Frame):
         self.full_display.set_focus()
         self._update_title()
         self._fetch_weather(city, lat, lon, "full")
+        self._fetch_full_alerts(city, lat, lon)
+
+    def _fetch_full_alerts(self, city, lat, lon):
+        """Load the detailed view's ALERTS section (US only - NWS has no
+        coverage elsewhere, so the section is omitted rather than empty)."""
+        self.full_alerts = []
+        self.full_alert_error = ""
+        if not self._is_us_coord(lat, lon):
+            self.full_alert_state = "off"
+            return
+        self.full_alert_state = "loading"
+        self.fetch.submit(
+            "full_alerts",
+            lambda: alert_service.fetch_alerts(lat, lon),
+            request_id=city,
+        )
+
+    def _on_full_alerts(self, city, alerts, error):
+        # Ignore results for a city the user has already navigated away from.
+        if (not hasattr(self, "current_full_city")
+                or self.current_full_city[0] != city):
+            return
+        if error:
+            self.full_alert_state = "error"
+            self.full_alert_error = error
+            self.statusbar.SetStatusText(f"Could not check alerts for {city}", 0)
+        else:
+            self.full_alert_state = "ok"
+            self.full_alerts = alerts or []
+            n = len(self.full_alerts)
+            self.statusbar.SetStatusText(
+                f"{n} active alert{'s' if n != 1 else ''} for {city}" if n
+                else f"No active alerts for {city}", 0)
+        self._render_full()
+
+    def _open_alert(self, payload):
+        """Activate a data row in the detailed view (alert sheet, or retry)."""
+        if payload == RETRY:
+            city, lat, lon = self.current_full_city
+            self._fetch_full_alerts(city, lat, lon)
+            self._render_full()
+            return
+        dlg = AlertDetailDialog(self, payload)
+        dlg.ShowModal()
+        dlg.Destroy()
 
     def nav_day(self, direction):
         """Navigate the detailed view by day (direction 0 resets to today)."""
@@ -803,12 +861,25 @@ class MainFrame(wx.Frame):
         return f"{'+' if n > 0 else ''}{n} day" + ("s" if abs(n) != 1 else "")
 
     def _render_full(self):
-        if self.current_full_data is None or not hasattr(self, "current_full_city"):
+        if not hasattr(self, "current_full_city"):
             return
         city = self.current_full_city[0]
         data = self.current_full_data
+
+        # Alerts sit directly under the city heading - ahead of the forecast,
+        # but never displacing the line that says which city this is. Today
+        # only: a warning in force now says nothing about the forecast for
+        # another day (matches iOS, which clears alerts for a date offset).
         if self.day_offset == 0:
-            lines = build_full_weather_lines(city, data, self.settings, self.fmt)
+            alert_lines, alert_rows = section_lines(
+                self.full_alert_state, self.full_alerts, self.full_alert_error)
+        else:
+            alert_lines, alert_rows = [], {}
+
+        if data is None:
+            weather_lines = [f"Report for {city}", "=" * 40, "Loading forecast..."]
+        elif self.day_offset == 0:
+            weather_lines = build_full_weather_lines(city, data, self.settings, self.fmt)
         else:
             ref = data.get("current", {}).get("time", "")[:10]
             try:
@@ -816,9 +887,24 @@ class MainFrame(wx.Frame):
                 target = (date.fromisoformat(ref) + timedelta(days=self.day_offset)).isoformat()
             except Exception:
                 return
-            lines = build_day_lines(city, data, self.settings, self.fmt, target,
-                                    self._day_label())
-        self.full_display.set_lines(lines)
+            weather_lines = build_day_lines(city, data, self.settings, self.fmt, target,
+                                            self._day_label())
+
+        # Alerts and forecast arrive independently, so this re-renders while the
+        # user may already be reading. Hold their place unless the city or day
+        # changed, which would make the old position meaningless.
+        key = (city, self.day_offset)
+        keep = key == getattr(self, "_last_render_key", None)
+        self._last_render_key = key
+
+        # Splice the alerts in after the "Report for <city>" heading and its
+        # rule, shifting the activation map to match their new positions.
+        lines = list(weather_lines)
+        at = min(2, len(lines))
+        lines[at:at] = alert_lines
+        row_alerts = {i + at: a for i, a in alert_rows.items()}
+
+        self.full_display.set_lines(lines, row_alerts, keep_selection=keep)
         self._update_title()
 
     def _update_title(self):
@@ -826,8 +912,15 @@ class MainFrame(wx.Frame):
         app = "WeatherFast"
         if self.book.GetSelection() == 1 and hasattr(self, "current_full_city"):
             city = self.current_full_city[0]
+            # Lead the window name with the worst active alert so the screen
+            # reader announces it when the detailed view is entered.
+            mark = ""
+            if self.day_offset == 0 and self.full_alert_state == "ok":
+                top = highest(self.full_alerts)
+                if top is not None:
+                    mark = f"{top.severity.upper()} ALERT - "
             if self.day_offset == 0:
-                self.SetTitle(f"{city} - Full Weather - {app}")
+                self.SetTitle(f"{mark}{city} - Full Weather - {app}")
             else:
                 self.SetTitle(f"{city} - {self._day_label()} - {app}")
         else:
@@ -836,6 +929,7 @@ class MainFrame(wx.Frame):
     def on_back(self, event):
         self.book.SetSelection(0)
         self.city_list.SetFocus()
+        self.statusbar.SetStatusText("Ready", 0)
         self._update_title()
 
     def on_config(self, event):
@@ -898,10 +992,12 @@ class MainFrame(wx.Frame):
             else:
                 self._add_location_city(event.payload)
         elif event.kind == "alert_badge":
-            # Best-effort: only badge on a positive result; never annotate on
-            # error (can't distinguish "no alerts" from "couldn't check").
-            if not event.error and event.payload:
-                self._apply_alert_badge(event.request_id)
+            # Best-effort: never annotate on error (a failed check can't be
+            # distinguished from "no alerts", and must not read as either).
+            if not event.error:
+                self._apply_alert_badge(event.request_id, event.payload or [])
+        elif event.kind == "full_alerts":
+            self._on_full_alerts(event.request_id, event.payload, event.error)
 
     @staticmethod
     def _is_us_coord(lat, lon):
@@ -921,15 +1017,28 @@ class MainFrame(wx.Frame):
             return
         self.fetch.submit(
             "alert_badge",
-            lambda: alert_service.has_active_alerts(lat, lon),
+            lambda: alert_service.fetch_alerts(lat, lon),
             request_id=city,
         )
 
-    def _apply_alert_badge(self, city):
+    def _apply_alert_badge(self, city, alerts):
+        self._row_badges[city] = city_row_badge(alerts)
+        self._refresh_city_row(city)
+
+    def _refresh_city_row(self, city):
+        """Repaint a city's row from its weather text plus its alert badge.
+
+        The two arrive from independent fetches, so the row is always composed
+        from both rather than appended to in place - otherwise a weather
+        refresh silently drops the badge.
+        """
+        base = self._row_text.get(city)
+        if base is None:
+            return
+        text = base + self._row_badges.get(city, "")
         for i in range(self.city_list.GetCount()):
-            text = self.city_list.GetString(i)
-            if text.startswith(city + " - ") and "[ALERT]" not in text:
-                self.city_list.SetString(i, text + "  [ALERT]")
+            if self.city_list.GetString(i).startswith(city + " - "):
+                self.city_list.SetString(i, text)
                 break
 
     def on_weather_ready(self, city, data):
@@ -983,12 +1092,9 @@ class MainFrame(wx.Frame):
                 precip_text = " [Rain]"
 
             temp_display = self.fmt.temperature_short(temp_c)
-            new_text = f"{city} - {temp_display}{cloud_text}{precip_text}{daily_temps}"
-
-            for i in range(self.city_list.GetCount()):
-                if self.city_list.GetString(i).startswith(city + " - "):
-                    self.city_list.SetString(i, new_text)
-                    break
+            self._row_text[city] = (
+                f"{city} - {temp_display}{cloud_text}{precip_text}{daily_temps}")
+            self._refresh_city_row(city)
 
             # Best-effort alert badge for US cities (cached 5 min).
             if city in self.cities:

--- a/windows/fastweather/services/alert_service.py
+++ b/windows/fastweather/services/alert_service.py
@@ -31,11 +31,3 @@ def fetch_alerts(lat, lon, use_cache=True):
     alerts.sort(key=lambda a: a.sort_key)
     _cache.set(key, alerts)
     return alerts
-
-
-def has_active_alerts(lat, lon):
-    """Best-effort boolean for badging; returns None if the check failed."""
-    try:
-        return len(fetch_alerts(lat, lon)) > 0
-    except Exception:
-        return None

--- a/windows/fastweather/ui/accessible_list.py
+++ b/windows/fastweather/ui/accessible_list.py
@@ -16,28 +16,90 @@ def _is_visible_line(line):
 class AccessibleLinesPanel(wx.Panel):
     """A monospace single-select ListBox that renders a list of text lines."""
 
-    def __init__(self, parent):
+    def __init__(self, parent, activatable=False):
+        """``activatable`` enables Enter on rows carrying a payload (see
+        set_lines). It is opt-in because it requires wx.WANTS_CHARS, which
+        stops Enter from reaching a dialog's default button; panels that are
+        pure output keep the plain style and their existing key behavior.
+        """
         super().__init__(parent)
         sizer = wx.BoxSizer(wx.VERTICAL)
-        self.listbox = wx.ListBox(self, style=wx.LB_SINGLE)
+        # HSCROLL: alert text is rendered a whole paragraph per row, which can
+        # run well past the window width.
+        style = wx.LB_SINGLE | wx.LB_HSCROLL
+        if activatable:
+            style |= wx.WANTS_CHARS
+        self.listbox = wx.ListBox(self, style=style)
         self.listbox.SetFont(
             wx.Font(10, wx.FONTFAMILY_TELETYPE, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
         )
         sizer.Add(self.listbox, 1, wx.EXPAND)
         self.SetSizer(sizer)
 
-    def set_lines(self, lines):
-        """Replace contents with the given lines (filtered for accessibility)."""
+        self._row_data = {}       # listbox row -> caller payload
+        self._on_activate = None
+        if activatable:
+            self.listbox.Bind(wx.EVT_KEY_DOWN, self._on_key)
+            self.listbox.Bind(wx.EVT_LISTBOX_DCLICK, lambda e: self._activate())
+
+    def set_lines(self, lines, row_data=None, keep_selection=False):
+        """Replace contents with the given lines (filtered for accessibility).
+
+        ``row_data`` optionally maps an index in ``lines`` to a payload for that
+        line; indexes are re-keyed to surviving rows so filtering can't misalign
+        them. Activating such a row (Enter or double-click) invokes the handler
+        registered with set_activate_handler().
+
+        ``keep_selection`` re-selects the previously selected line by its text
+        rather than its index, so a background refresh that inserts lines above
+        the reading position doesn't move the user.
+        """
+        prev = (self.listbox.GetStringSelection()
+                if keep_selection and self.listbox.GetSelection() != wx.NOT_FOUND
+                else None)
         self.listbox.Clear()
-        for line in lines:
-            if _is_visible_line(line):
-                self.listbox.Append(line)
+        self._row_data = {}
+        for i, line in enumerate(lines):
+            if not _is_visible_line(line):
+                continue
+            if row_data and i in row_data:
+                self._row_data[self.listbox.GetCount()] = row_data[i]
+            self.listbox.Append(line)
         if self.listbox.GetCount() > 0:
-            self.listbox.SetSelection(0)
+            restored = self.listbox.FindString(prev) if prev else wx.NOT_FOUND
+            self.listbox.SetSelection(restored if restored != wx.NOT_FOUND else 0)
+
+    def set_activate_handler(self, handler):
+        """Register ``handler(payload)`` for Enter / double-click on data rows."""
+        self._on_activate = handler
+
+    def _activate(self):
+        """Fire the handler for the selected row; True if the row had one."""
+        payload = self._row_data.get(self.listbox.GetSelection())
+        if payload is None or not self._on_activate:
+            return False
+        self._on_activate(payload)
+        return True
+
+    def _on_key(self, event):
+        """Enter activates a data row; Tab is re-implemented because
+        WANTS_CHARS also intercepts it, which would trap focus in the list."""
+        kc = event.GetKeyCode()
+        if kc in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER):
+            if self._activate():
+                return
+            event.Skip()
+        elif kc == wx.WXK_TAB:
+            flags = (wx.NavigationKeyEvent.IsBackward if event.ShiftDown()
+                     else wx.NavigationKeyEvent.IsForward)
+            self.listbox.Navigate(flags)
+        else:
+            event.Skip()
 
     def set_message(self, text):
         """Show a single status line (e.g. 'Loading...' or an error)."""
         self.listbox.Clear()
+        self._row_data = {}
         self.listbox.Append(text)
 
     def append(self, text):
@@ -45,6 +107,7 @@ class AccessibleLinesPanel(wx.Panel):
 
     def clear(self):
         self.listbox.Clear()
+        self._row_data = {}
 
     def set_focus(self):
         self.listbox.SetFocus()

--- a/windows/fastweather/ui/alert_format.py
+++ b/windows/fastweather/ui/alert_format.py
@@ -1,6 +1,13 @@
-"""Shared formatting for weather alerts (list rows and full detail)."""
+"""Shared formatting for weather alerts (list rows, city rows, and full detail).
+
+Everything a screen reader announces about an alert is built here so the city
+list, the detailed view's ALERTS section, and the alert sheets stay consistent.
+"""
 
 from datetime import datetime
+
+# Sentinel payload for the ALERTS section's "check again" row.
+RETRY = "__retry__"
 
 
 def fmt_time(iso):
@@ -20,6 +27,105 @@ def summary_row(alert):
     return text
 
 
+def highest(alerts):
+    """The most critical alert in a list (iOS ListRowView.highestSeverityAlert)."""
+    if not alerts:
+        return None
+    return min(alerts, key=lambda a: a.sort_key)
+
+
+def city_row_badge(alerts):
+    """Suffix appended to a My Cities row, naming the worst active alert.
+
+    A bare '[ALERT]' can't distinguish an Extreme tornado warning from a Minor
+    frost advisory, so the severity and event are spoken on the row itself.
+    """
+    top = highest(alerts)
+    if top is None:
+        return ""
+    more = len(alerts) - 1
+    extra = f", +{more} more" if more > 0 else ""
+    return f"  [{top.severity.upper()}: {top.event}{extra}]"
+
+
+def detail_row(alert):
+    """One alert as a single arrow-stop in the detailed view's ALERTS section."""
+    parts = [f"{alert.severity.upper()}: {alert.event}"]
+    if alert.headline and alert.headline != alert.event:
+        parts.append(alert.headline)
+    until = fmt_time(alert.ends)
+    if until:
+        parts.append(f"until {until}")
+    return " - ".join(parts)
+
+
+def section_lines(state, alerts=None, error=""):
+    """The ALERTS block for the detailed view, mirroring iOS WeatherAlertsSection.
+
+    Returns ``(lines, row_actions)`` where ``row_actions`` maps an index within
+    ``lines`` to what activating that line does: a WeatherAlert opens its sheet,
+    and RETRY re-runs the check (the iOS section's Retry button). ``state`` is
+    one of: 'loading', 'error', 'ok', or 'off' (non-US, where NWS has no
+    coverage and the section is omitted entirely).
+    """
+    if state == "off":
+        return [], {}
+
+    lines = ["ALERTS"]
+    row_alerts = {}
+
+    if state == "loading":
+        lines.append("Checking for alerts...")
+    elif state == "error":
+        # Safety invariant: a failed check is never reported as "no alerts".
+        lines.append("Could not check for alerts.")
+        if error:
+            lines.append(f"Reason: {error}")
+        lines.append("This does NOT mean there are no alerts.")
+        row_alerts[len(lines)] = RETRY
+        lines.append("Press Enter here to check again.")
+    elif not alerts:
+        lines.append("No active alerts.")
+    else:
+        # No count or "press Enter" preamble: the alert rows speak for
+        # themselves and an extra arrow-stop just delays reaching them.
+        for a in alerts:
+            row_alerts[len(lines)] = a
+            lines.append(detail_row(a))
+
+    lines.append("")
+    return lines, row_alerts
+
+
+def unwrap(text):
+    """Rejoin NWS text into logical paragraphs.
+
+    NWS hard-wraps its products at ~68 columns, so a sentence arrives split
+    across several physical lines ("...may cause heat\\nillness to occur."").
+    Rendering those verbatim as list rows strands fragments like "illness" on a
+    row of their own. Paragraphs break on blank lines and on the bullet markers
+    NWS uses ('* WHAT...', '* IMPACTS...'); everything else is a continuation.
+    """
+    paragraphs = []
+    current = []
+
+    def flush():
+        if current:
+            paragraphs.append(" ".join(current))
+            current.clear()
+
+    for raw in (text or "").split("\n"):
+        line = raw.strip()
+        if not line or line in ("&&", "$$"):  # NWS product delimiters
+            flush()
+            continue
+        if line.startswith("*"):
+            flush()
+        current.append(line)
+    flush()
+    return paragraphs
+
+
 def detail_lines(alert):
     """Full accessible detail for a single alert, as a list of lines."""
     lines = [f"{alert.severity.upper()} - {alert.event}"]
@@ -34,17 +140,13 @@ def detail_lines(alert):
     lines.append("")
     if alert.description:
         lines.append("Details:")
-        for seg in alert.description.split("\n"):
-            seg = seg.strip()
-            if seg:
-                lines.append(f"  {seg}")
+        for para in unwrap(alert.description):
+            lines.append(f"  {para}")
         lines.append("")
     if alert.instruction:
         lines.append("Safety Instructions:")
-        for seg in alert.instruction.split("\n"):
-            seg = seg.strip()
-            if seg:
-                lines.append(f"  {seg}")
+        for para in unwrap(alert.instruction):
+            lines.append(f"  {para}")
         lines.append("")
     lines.append(f"Source: {alert.source}")
     if alert.details_url:

--- a/windows/fastweather/ui/dialogs/alert_detail_dialog.py
+++ b/windows/fastweather/ui/dialogs/alert_detail_dialog.py
@@ -1,0 +1,38 @@
+"""Standalone single-alert sheet (iOS AlertDetailView parity).
+
+Opened from any place that shows an alert row - currently the detailed view's
+ALERTS section - so the alert's full text is always one Enter away.
+"""
+
+import wx
+
+from ..accessible_list import AccessibleLinesPanel
+from ..alert_format import detail_lines
+
+
+class AlertDetailDialog(wx.Dialog):
+    def __init__(self, parent, alert):
+        super().__init__(parent, title=f"Weather Alert - {alert.event}", size=(700, 560))
+        self.alert = alert
+
+        panel = wx.Panel(self)
+        vbox = wx.BoxSizer(wx.VERTICAL)
+
+        self.lines = AccessibleLinesPanel(panel)
+        self.lines.set_lines(detail_lines(alert))
+        vbox.Add(self.lines, 1, wx.EXPAND | wx.ALL, 8)
+
+        row = wx.BoxSizer(wx.HORIZONTAL)
+        if alert.details_url:
+            source_btn = wx.Button(panel, label=f"View on {alert.source} Website")
+            source_btn.Bind(wx.EVT_BUTTON,
+                            lambda e: wx.LaunchDefaultBrowser(alert.details_url))
+            row.Add(source_btn, 0, wx.RIGHT, 8)
+        close_btn = wx.Button(panel, wx.ID_CLOSE, "Close")
+        row.Add(close_btn, 0)
+        vbox.Add(row, 0, wx.ALIGN_CENTER | wx.ALL, 8)
+
+        panel.SetSizer(vbox)
+        self.SetEscapeId(wx.ID_CLOSE)
+        self.Bind(wx.EVT_BUTTON, lambda e: self.EndModal(wx.ID_CLOSE), id=wx.ID_CLOSE)
+        wx.CallAfter(self.lines.set_focus)

--- a/windows/tests/test_alerts.py
+++ b/windows/tests/test_alerts.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastweather.models import alert as A
 from fastweather.services import alert_service, nws
+from fastweather.ui import alert_format as F
 
 
 def _future(hours=6):
@@ -128,11 +129,96 @@ class AlertServiceTests(unittest.TestCase):
         alerts = alert_service.fetch_alerts(9.0, 9.0, use_cache=False)
         self.assertEqual([a.event for a in alerts], ["Severe Now", "Minor Now"])
 
-    def test_error_none(self):
+    def test_failure_raises(self):
+        # Callers must be able to tell "couldn't check" from "no alerts".
         def boom(*a, **k):
             raise RuntimeError("down")
         alert_service.http.get_json = boom
-        self.assertIsNone(alert_service.has_active_alerts(9.0, 9.0))
+        with self.assertRaises(RuntimeError):
+            alert_service.fetch_alerts(9.0, 9.0, use_cache=False)
+
+
+class CityRowBadgeTests(unittest.TestCase):
+    def _mk(self, event, sev):
+        return A.WeatherAlert(event, sev, "", "", "", "", _future(), "Area")
+
+    def test_no_alerts_no_badge(self):
+        self.assertEqual(F.city_row_badge([]), "")
+
+    def test_names_worst_alert(self):
+        badge = F.city_row_badge([self._mk("Frost Advisory", "Minor"),
+                                  self._mk("Tornado Warning", "Extreme")])
+        self.assertIn("EXTREME", badge)
+        self.assertIn("Tornado Warning", badge)
+
+    def test_counts_the_rest(self):
+        alerts = [self._mk("Tornado Warning", "Extreme"),
+                  self._mk("Flood Warning", "Severe"),
+                  self._mk("Frost Advisory", "Minor")]
+        self.assertIn("+2 more", F.city_row_badge(alerts))
+        self.assertNotIn("more", F.city_row_badge(alerts[:1]))
+
+
+class UnwrapTests(unittest.TestCase):
+    # NWS hard-wraps at ~68 columns, mid-sentence.
+    NWS = ("* WHAT...Heat index values of 100 to 103 degrees expected.\n\n"
+           "* IMPACTS...Hot temperatures and high humidity may cause heat\n"
+           "illnesses.\n\n"
+           "* ADDITIONAL DETAILS...Areas along the immediate Lake Michigan\n"
+           "shoreline may see some relief.\n&&")
+
+    def test_sentence_is_not_split(self):
+        paras = F.unwrap(self.NWS)
+        self.assertIn("* IMPACTS...Hot temperatures and high humidity may cause "
+                      "heat illnesses.", paras)
+        # No row is a stranded fragment of the previous sentence.
+        self.assertNotIn("illnesses.", paras)
+
+    def test_one_paragraph_per_bullet(self):
+        self.assertEqual(len(F.unwrap(self.NWS)), 3)
+
+    def test_bullets_split_without_blank_lines(self):
+        paras = F.unwrap("* WHAT...Rain.\n* WHERE...Dane.")
+        self.assertEqual(paras, ["* WHAT...Rain.", "* WHERE...Dane."])
+
+    def test_product_delimiters_dropped(self):
+        self.assertNotIn("&&", F.unwrap(self.NWS))
+        self.assertNotIn("$$", F.unwrap("Stay hydrated.\n$$"))
+
+    def test_empty(self):
+        self.assertEqual(F.unwrap(""), [])
+        self.assertEqual(F.unwrap(None), [])
+
+
+class SectionLinesTests(unittest.TestCase):
+    def _mk(self, event, sev):
+        return A.WeatherAlert(event, sev, "", "", "", "", _future(), "Area")
+
+    def test_off_is_omitted_entirely(self):
+        self.assertEqual(F.section_lines("off"), ([], {}))
+
+    def test_error_is_never_no_alerts(self):
+        lines, actions = F.section_lines("error", [], "down")
+        text = " ".join(lines)
+        self.assertIn("Could not check", text)
+        self.assertNotIn("No active alerts", text)
+        self.assertIn(F.RETRY, actions.values())
+
+    def test_empty_says_no_alerts(self):
+        lines, actions = F.section_lines("ok", [])
+        self.assertIn("No active alerts.", lines)
+        self.assertEqual(actions, {})
+
+    def test_alert_rows_are_actionable(self):
+        alerts = [self._mk("Tornado Warning", "Extreme"), self._mk("Flood Warning", "Severe")]
+        lines, actions = F.section_lines("ok", alerts)
+        # Header then the alerts themselves - no count/instruction preamble.
+        self.assertEqual(lines[0], "ALERTS")
+        self.assertTrue(lines[1].startswith("EXTREME: Tornado Warning"))
+        # Every mapped index points at that alert's own row.
+        self.assertEqual(len(actions), 2)
+        for idx, alert in actions.items():
+            self.assertIn(alert.event, lines[idx])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Brings weather alerts into the city's Full Weather report and fixes the alert-text line breaks, then bumps to 3.0.1 and prepares the release.

## The bug

The city list could mark a city as having an alert, but opening that city's Full Weather showed no sign of it â€” `build_full_weather_lines` emitted only CURRENT/HOURLY/DAILY and `on_full_weather` never fetched alerts. The only route to the alert was the Weather menu, which is the wrong place to hide a safety feature.

## Changes

**ALERTS section in the report**, spliced in after the `Report for <city>` heading and ahead of CURRENT, with the same four states as the iOS `WeatherAlertsSection`: checking, couldn't-check (with a row you can press Enter on to retry), no active alerts, and the alerts themselves. A failed check is never rendered as "no alerts". Non-US cities omit the section rather than showing an empty one. Today only, matching iOS.

**Alert text no longer breaks mid-sentence.** NWS hard-wraps its products at ~68 columns, and `detail_lines` emitted each physical line as its own row â€” the live Madison heat advisory stranded `illnesses.` alone on a row. `alert_format.unwrap()` rejoins continuation lines into paragraphs, breaking only on blank lines and NWS bullet markers. Rows can now exceed the window width, so the lines panel gains `LB_HSCROLL`.

**Enter works on the report list.** `AccessibleLinesPanel`'s listbox was created without `wx.WANTS_CHARS`, so Enter never reached a key handler â€” the same bug c8b5cae fixed for the alert browser lists. Made opt-in (`activatable=True`) because `WANTS_CHARS` also stops Enter reaching a dialog's default button; only the report list sets it, so the eight other dialogs using this panel are unaffected. Tab is re-implemented so focus can still leave the list.

**City row badge** names the worst alert and the count of others, instead of a bare `[ALERT]` that read identically for an extreme tornado warning and a minor frost advisory. The row is now composed from its weather text plus a separately held badge, so a weather refresh no longer drops it.

Removes `alert_service.has_active_alerts()`, now unused.

## Release plumbing

The workflow published auto-generated notes only, which is why 3.0.0's notes had to be hand-edited after publishing. It now uses `windows/RELEASE_NOTES_<version>.md` as the release body (generated changelog appended below), and fails fast before the build and signing if that file is missing.

## Testing

91 tests pass. New coverage for the badge, all four section states, and `unwrap()` against the real NWS text shape. The rendering was verified against the live Madison Heat Advisory rather than a synthetic sample.

Not verified automatically: the Enter keypress itself. `wx.UIActionSimulator` delivered no key events in my environment, so that fix rests on matching the pattern already proven for `city_list`. Kelly confirmed it by hand against a local build (reaching the alert detail requires it).

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
