### PR TITLE
Windows: fix the updater by switching to a one-dir build

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -120,11 +120,21 @@ jobs:
           endpoint: https://eus.codesigning.azure.net/
           signing-account-name: kellylford
           certificate-profile-name: kellyford-public
-          files-folder: ${{ github.workspace }}\windows\dist
+          files-folder: ${{ github.workspace }}\windows\dist\WeatherFast
           files-folder-filter: exe
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
+
+      # Re-zip after signing. build.py also writes this zip, but it runs before
+      # the signing step, so that copy holds an unsigned executable.
+      - name: Package portable zip (post-signing)
+        shell: pwsh
+        run: |
+          $zip = "windows/dist/WeatherFast-portable.zip"
+          if (Test-Path $zip) { Remove-Item $zip }
+          Compress-Archive -Path windows/dist/WeatherFast -DestinationPath $zip
+          Write-Host "Portable zip: $((Get-Item $zip).Length / 1MB) MB"
 
       - name: Build installer (Inno Setup)
         shell: pwsh
@@ -155,7 +165,7 @@ jobs:
         with:
           name: WeatherFast-${{ steps.ver.outputs.version }}
           path: |
-            windows/dist/WeatherFast.exe
+            windows/dist/WeatherFast-portable.zip
             installer/Output/WeatherFast-*-Setup.exe
           if-no-files-found: error
           retention-days: 14
@@ -168,6 +178,6 @@ jobs:
           body_path: windows/RELEASE_NOTES_${{ steps.ver.outputs.version }}.md
           generate_release_notes: true
           files: |
-            windows/dist/WeatherFast.exe
+            windows/dist/WeatherFast-portable.zip
             installer/Output/WeatherFast-*-Setup.exe
           fail_on_unmatched_files: true

--- a/installer/weatherfast.iss
+++ b/installer/weatherfast.iss
@@ -47,8 +47,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional icons:"; Flags: unchecked
 
 [Files]
-; The PyInstaller one-file build output (produced by ../windows/build.py).
-Source: "..\windows\dist\WeatherFast.exe"; DestDir: "{app}"; Flags: ignoreversion
+; The PyInstaller one-dir build output (produced by ../windows/build.py): the
+; executable plus its _internal support folder.
+Source: "..\windows\dist\WeatherFast\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{autostartmenu}\WeatherFast"; Filename: "{app}\{#MyAppExeName}"
@@ -56,3 +57,32 @@ Name: "{autodesktop}\WeatherFast"; Filename: "{app}\{#MyAppExeName}"; Tasks: des
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "Launch WeatherFast"; Flags: nowait postinstall skipifsilent
+
+[Code]
+// Force-close any WeatherFast process still holding the installed executable.
+// (Comments here use // rather than braces: Inno's brace comments do not nest,
+// so an {app}-style constant inside one would terminate it early.)
+//
+// AppMutex and CloseApplications are not sufficient when upgrading from a 3.0.x
+// one-file build. Those ran a bootloader parent plus a Python child, and only
+// the child created WeatherFastRunning - so once it exited the mutex was gone
+// even though the parent was still alive holding the .exe open, parked on the
+// bootloader's "Failed to remove temporary directory" dialog. Restart Manager
+// cannot shift that either: a process whose message loop has already ended does
+// not act on the WM_CLOSE that CloseApplications sends. The result was setup
+// failing with "DeleteFile failed; code 5. Access is denied."
+//
+// Killing it is safe here: in that state the application has finished its work
+// and is only displaying a shutdown warning. A genuinely running instance is
+// still caught earlier by AppMutex, which prompts the user first.
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  ResultCode: Integer;
+begin
+  Result := '';  // never block the install - a lock still surfaces as a file error
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM WeatherFast.exe', '',
+       SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  // 128 = "no such process", the normal case. Give Windows a moment either way
+  // so the handle is released before the file copy starts.
+  Sleep(500);
+end;

--- a/windows/RELEASE_NOTES_3.0.1.md
+++ b/windows/RELEASE_NOTES_3.0.1.md
@@ -1,53 +1,88 @@
-WeatherFast 3.0.1 brings weather alerts into the city's own weather report and
-makes alert text far easier to read.
+WeatherFast 3.0.1 is a complete rebuild of the Windows app — same free data (no
+account or API key), with a much larger feature set, a proper installer, and
+signed binaries. It replaces 3.0.0, which has been withdrawn.
 
-## Weather alerts in the full weather report
+## Install
 
-Previously, the city list could mark a city as having an alert, but opening
-that city's Full Weather showed no sign of it — the alert was only reachable
-from the Weather menu. Alerts now appear in the report itself, directly under
-the city heading and ahead of the forecast:
+- **Installer (recommended):** `WeatherFast-3.0.1-Setup.exe` — per-user install,
+  Start Menu shortcut, no admin required, and automatic updates going forward.
+- **Portable:** `WeatherFast-portable.zip` — extract the folder anywhere and run
+  `WeatherFast.exe` from it. Nothing is installed. Keep the folder together; the
+  application needs the `_internal` folder beside the executable.
+
+Both downloads are code-signed.
+
+### If you already have 3.0.0
+
+Please **uninstall 3.0.0 first** (Settings → Apps, or the Start Menu uninstall
+entry), then install 3.0.1. 3.0.0 had a packaging fault that could leave the
+application running invisibly after you closed it, holding its own files open —
+which made in-place updates fail with "DeleteFile failed; code 5. Access is
+denied." That is fixed in 3.0.1, but a clean install is the reliable way across.
+
+If an install ever does report that error, close WeatherFast (or end
+`WeatherFast.exe` in Task Manager) and run the installer again.
+
+## Highlights
+
+- **Place search** for cities, ZIP/postal codes, addresses, and specific places
+  (airports, universities, landmarks), always with a selectable results list.
+- **Full weather:** current conditions, a plain-language "Today's Outlook",
+  24-hour hourly, and a multi-day forecast, with day-by-day navigation.
+- **Weather alerts:** shown in the city's own weather report, plus a full
+  **alert browser** for the US and Canada — filter by severity and hazard type
+  and drill into affected areas.
+- **Expected Precipitation** next-hour nowcast, **Weather Around Me** (eight
+  directions plus a directional explorer), **Historical** weather (single day,
+  same-day-across-years, daily browse), **Marine**, **Astronomy (moon)**, and a
+  configurable **My Data** section (marine, air quality, pollen, and more).
+- **Browse cities** by US state or country with sorting and favorites.
+- Configurable fields and units (wind in mph / km/h / m/s), defaulting to your
+  Windows region on first run.
+- **Automatic updates** and a built-in **User Guide** (Help, or F1).
+
+## New in 3.0.1
+
+**Weather alerts appear in the weather report.** In 3.0.0 the city list could
+mark a city as having an alert, but opening that city's Full Weather showed no
+sign of it — the alert was only reachable from the Weather menu. Alerts now sit
+directly under the city heading, ahead of the forecast:
 
 ```
 Report for Madison, Wisconsin
 ALERTS
-MODERATE: Heat Advisory - Heat Advisory issued July 26 at 5:10AM CDT... - until Sun Jul 26 09:00 PM
+MODERATE: Heat Advisory - until Sun Jul 26 09:00 PM
 CURRENT
 ...
 ```
 
-- Press **Enter** on an alert to open its full text: description, safety
-  instructions, affected areas, valid period, and a button to open the
-  official NWS page.
-- A check that fails is never reported as "no alerts". It says so plainly and
-  offers a line you can press Enter on to try again.
-- Cities outside the US omit the section entirely rather than showing an empty
-  one, since the National Weather Service has no coverage there.
-- Alerts are shown for today only — a warning in force now says nothing about
-  another day's forecast.
+Press **Enter** on an alert for its full text: description, safety
+instructions, affected areas, valid period, and a link to the official NWS
+page. A check that fails is never reported as "no alerts" — it says so plainly
+and offers a line you can press Enter on to try again. Cities outside the US
+omit the section, since the National Weather Service has no coverage there.
 
-## Clearer alert list entries
-
-The city list previously appended a bare `[ALERT]`, which read identically for
-an extreme tornado warning and a minor frost advisory. It now names the most
-severe alert, and how many others there are:
+**The city list names the alert.** Instead of a bare `[ALERT]`, which read the
+same for an extreme tornado warning and a minor frost advisory, the row now
+names the most severe alert and how many others there are:
 
 ```
 Madison, Wisconsin - 78°F, Cloudy (High: 80°F, Low: 60°F)  [EXTREME: Tornado Warning, +1 more]
 ```
 
-The window title also leads with the severity when a city has active alerts, so
-a screen reader announces it on entering the report.
+The window title also leads with the severity, so a screen reader announces it
+on entering the report.
 
-## Fixes
+**Alert text no longer breaks mid-sentence.** The National Weather Service
+hard-wraps its bulletins at about 68 columns, and each of those physical lines
+was becoming its own row — stranding fragments like "illnesses." alone on a
+line. Alert text is now rejoined into whole paragraphs.
 
-- **Alert text no longer breaks mid-sentence.** The National Weather Service
-  hard-wraps its text at about 68 columns, and each of those physical lines was
-  becoming its own row — stranding fragments like "illnesses." alone on a line.
-  Alert text is now rejoined into whole paragraphs, one per row. This affects
-  every place alerts are shown, including the Weather Alerts sheet and the
-  alert browser.
-- **Enter now works on the weather report.** Rows in the report list never
-  received the Enter key, because the list was created without the style that
-  lets a control claim it.
-- A city row's alert marker is no longer lost when its weather refreshes.
+**Other fixes:**
+
+- Enter now works on rows in the weather report.
+- A city's alert marker is no longer lost when its weather refreshes.
+- Fixed the packaging fault described under *If you already have 3.0.0*, which
+  also prevented automatic updates from installing.
+
+Full user guide: https://kellylford.github.io/WeatherFast/

--- a/windows/build.py
+++ b/windows/build.py
@@ -73,12 +73,24 @@ def main():
     print("-" * 60)
     
     # PyInstaller command
+    #
+    # --onedir, NOT --onefile. A one-file build unpacks itself to a _MEIxxxx
+    # temp directory at startup and deletes it on exit; when that delete fails
+    # (antivirus still scanning it, a handle still open) the bootloader shows a
+    # modal "Failed to remove temporary directory" warning and the process stays
+    # alive holding WeatherFast.exe open. That breaks the in-app updater every
+    # time: the installer cannot replace a locked file ("DeleteFile failed; code
+    # 5"). One-file also splits into a bootloader parent plus a child process,
+    # and only the child holds the AppMutex the installer looks for - so the
+    # installer's running-app check misses the parent that owns the lock.
+    # One-dir has no extraction step and runs as a single process, which removes
+    # both problems and starts faster.
     cmd = [
         sys.executable, "-m", "PyInstaller",
         "--noconfirm", # Overwrite output directory
         "--name=WeatherFast",
         "--windowed",  # No console window
-        "--onefile",   # Single executable file
+        "--onedir",    # Folder build (see note above - do not use --onefile)
         "--icon=NONE", # No icon (you can add one later)
         "--add-data", "city.json;.", # Embed city.json as a resource
         "--add-data", "us-cities-cached.json;.", # Embed US cities cache
@@ -103,24 +115,37 @@ def main():
     print("✓ Build complete!")
     print()
     
-    # Check output
-    dist_dir = "dist"
-    exe_path = os.path.join(dist_dir, "WeatherFast.exe")
-    
-    if os.path.exists(exe_path):
-        print(f"Executable location: {os.path.abspath(exe_path)}")
-        print()
-        
-        size_mb = os.path.getsize(exe_path) / (1024 * 1024)
-        print(f"Executable size: {size_mb:.1f} MB")
-        print()
-        
-        print("To distribute:")
-        print(f"  Just share the 'WeatherFast.exe' file.")
-        print()
-    else:
+    # Check output. --onedir puts everything in dist/WeatherFast/.
+    app_dir = os.path.join("dist", "WeatherFast")
+    exe_path = os.path.join(app_dir, "WeatherFast.exe")
+
+    if not os.path.exists(exe_path):
         print("✗ Build output not found!")
         return 1
+
+    print(f"Application folder: {os.path.abspath(app_dir)}")
+    print()
+
+    total = sum(
+        os.path.getsize(os.path.join(root, f))
+        for root, _, files in os.walk(app_dir)
+        for f in files
+    )
+    print(f"Folder size: {total / (1024 * 1024):.1f} MB")
+    print()
+
+    # Portable download: the whole folder, zipped. A one-dir build has no
+    # single portable .exe (see the --onedir note above).
+    zip_path = shutil.make_archive(
+        os.path.join("dist", "WeatherFast-portable"), "zip", "dist", "WeatherFast")
+    print(f"Portable zip: {os.path.abspath(zip_path)} "
+          f"({os.path.getsize(zip_path) / (1024 * 1024):.1f} MB)")
+    print()
+
+    print("To distribute:")
+    print("  Installer: build installer/weatherfast.iss over dist/WeatherFast.")
+    print("  Portable:  share WeatherFast-portable.zip (extract the folder and run).")
+    print()
     
     print()
     print("=" * 60)


### PR DESCRIPTION
3.0.1 had to be withdrawn: updating from 3.0.0 failed with `DeleteFile failed; code 5. Access is denied.`

## Cause

Confirmed on a machine actually in the failed state, not inferred.

A PyInstaller `--onefile` build unpacks itself to a `_MEIxxxx` temp directory and deletes it on exit. When that delete fails, the bootloader shows a modal "Failed to remove temporary directory" warning **and the process stays alive holding `WeatherFast.exe` open** — so the installer cannot replace it. The affected machine had three such processes parked and 39 orphaned `_MEI` directories going back a month.

`AppMutex` did not catch them: one-file runs a bootloader **parent** plus a Python **child**, and `__main__.py` creates `WeatherFastRunning` in the child. The child exits normally, releasing the mutex, while the parent keeps the lock. `CloseApplications` can't help either — Restart Manager sends `WM_CLOSE`, and the parent's message loop has already ended.

## Changes

- **`build.py`: `--onefile` → `--onedir`.** No extraction step, so the failure cannot occur, and the app runs as a single process, which makes `AppMutex` meaningful again. Faster startup too. Resource loading is unaffected — `paths.bundle_dir()` reads `sys._MEIPASS`, which one-dir sets to `_internal`.
- **Installer force-terminates lingering `WeatherFast.exe`** in `PrepareToInstall`, so upgrades from an already-stuck 3.0.x still succeed. Safe in that state: the app has finished its work and is only showing a shutdown warning; live instances are still caught by `AppMutex` first.
- **Portable download becomes `WeatherFast-portable.zip`** — one-dir has no single portable exe. The workflow re-zips *after* signing, because `build.py` writes its copy before the signing step runs.
- Release notes rewritten as the full 3.0 feature set plus the 3.0.1 changes, since 3.0.0 is being withdrawn and everyone installs this fresh.

## Verification

Tested against the real failure on the affected machine:

| Check | Result |
|---|---|
| Install over 3 stuck 3.0.0 processes | exit code 0 — the case that produced `code 5` |
| Process model while running | single process, no bootloader child |
| `_MEI` temp dirs created | none |
| Exit | clean — no warning dialog, no lingering process |
| Exe lock after exit | not locked; an installer can replace it |

That last row is the one that matters: in-place updates work from 3.0.1 onward. 91 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)